### PR TITLE
Allow migration methods to be longer than usual

### DIFF
--- a/rubocop-default-config.yml
+++ b/rubocop-default-config.yml
@@ -155,6 +155,10 @@ Metrics/MethodLength:
   Enabled: true
   CountComments: false
   Max: 10
+  ExcludedMethods:
+    - change
+    - up
+    - down
 Metrics/ParameterLists:
   Description: Avoid parameter lists longer than three or four parameters.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#too-many-params


### PR DESCRIPTION
The migration methods usually include way more code just because we have to define the whole table in there. IMHO we can just ignore it for these.