### PR TITLE
update config to modify rules

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -1,5 +1,11 @@
 ---
 detectors:
+  DuplicateMethodCall:
+    max_calls: 4
+
+  RepeatedConditional:
+    max_ifs: 4
+
   UncommunicativeModuleName:
     enabled: false
 


### PR DESCRIPTION
Updated the config rules for reek.

We are changing the rules for duplicate Method calls, because we end up always ignoring this lint as most of the time it is not necessary / inconvenient. We did not disable it we allowed the max calls to 4. 

We are also changing the repeated conditional rule and allowing it to do 4 max ifs. This too is most of the time ignored by devs and most of the time it does not make sense to fix the lint in complex services.