### PR TITLE
OPS-3897-update-rubocop-for-ruby-3-4

### DIFF
--- a/rubocop-default-config-ruby3.4.yml
+++ b/rubocop-default-config-ruby3.4.yml
@@ -1,0 +1,9 @@
+inherit_from:
+  - https://raw.githubusercontent.com/wtag/default-configs/master/rubocop-default-config.yml
+AllCops:
+  Exclude:
+    - "vendor/**/*"
+    - "db/schema.rb"
+  UseCache: false
+  TargetRubyVersion: 3.4
+  NewCops: enable


### PR DESCRIPTION
[OPS-3897](https://welltravel.atlassian.net/browse/OPS-3897)

- Update Rubocop for Ruby 3.4

[OPS-3897]: https://welltravel.atlassian.net/browse/OPS-3897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ